### PR TITLE
template fix and whitespace cleanup

### DIFF
--- a/keepalived/templates/keepalived.jinja
+++ b/keepalived/templates/keepalived.jinja
@@ -10,7 +10,7 @@
 # Global settings
 #---------------------------------------------------------------------
 global_defs {
-    notification_email { 
+    notification_email {
 {%- if 'notification_emails' in salt['pillar.get']('keepalived:global_defs')  %}
   {%- for email in salt['pillar.get']('keepalived:global_defs:notification_emails', {}).iteritems() %}
         {{ email }}
@@ -22,6 +22,7 @@ global_defs {
 {%- if 'smtp_timeout' in salt['pillar.get']('keepalived:global_defs')  %}
     smtp_timeout {{ salt['pillar.get']('keepalived:defaults:smtp_timeout') }}
 {%- endif %}
+}
 
 #---------------------------------------------------------------------
 # static network configuration
@@ -35,7 +36,7 @@ static_ipaddress {
 }
 {%- endif %}
 
-# static routes 
+# static routes
 {%- if 'static_routes' in salt['pillar.get']('keepalived') %}
 static_route {
   {%- for route in salt['pillar.get']('keepalived:static_routes', {}).iteritems() %}


### PR DESCRIPTION
/ fixed missing closing brackets of global_defs preventing vrrp scripts from working properly
```
<142>1 2015-09-16T08:30:05.002723+00:00 node1-proxy1 Keepalived_vrrp 16128 - -  Opening file '/etc/keepalived/keepalived.conf'.
<142>1 2015-09-16T08:30:05.002768+00:00 node1-proxy1 Keepalived_vrrp 16128 - -       chk_haproxy no match, ignoring...
```
/ removed trailing whitespaces