### PR TITLE
Fix keepalived.jinja template

### DIFF
--- a/keepalived/templates/keepalived.jinja
+++ b/keepalived/templates/keepalived.jinja
@@ -12,7 +12,7 @@
 global_defs {
     notification_email {
 {%- if 'notification_emails' in salt['pillar.get']('keepalived:global_defs')  %}
-  {%- for email in salt['pillar.get']('keepalived:global_defs:notification_emails', {}).iteritems() %}
+  {%- for email in salt['pillar.get']('keepalived:global_defs:notification_emails', []) %}
         {{ email }}
   {%- endfor %}
 {%- endif %}


### PR DESCRIPTION
This should be a list (of email addresses) and the template expects a dictionary. If you think it should be a dictionary, please update the pillar example to reflect that.