### PR TITLE
Fixed incorrect reference to pillar keepalived.defaults scope.

### DIFF
--- a/keepalived/templates/keepalived.jinja
+++ b/keepalived/templates/keepalived.jinja
@@ -17,10 +17,10 @@ global_defs {
   {%- endfor %}
 {%- endif %}
     }
-    notification_email_from {{ salt['pillar.get']('keepalived:defaults:notification_email_from', 'keepalived@'~salt['grains.get']('fqdn') ) }}
-    smtp_server {{ salt['pillar.get']('keepalived:defaults:smtp_server', 'localhost') }}
+    notification_email_from {{ salt['pillar.get']('keepalived:global_defs:notification_email_from', 'keepalived@'~salt['grains.get']('fqdn') ) }}
+    smtp_server {{ salt['pillar.get']('keepalived:global_defs:smtp_server', 'localhost') }}
 {%- if 'smtp_timeout' in salt['pillar.get']('keepalived:global_defs')  %}
-    smtp_timeout {{ salt['pillar.get']('keepalived:defaults:smtp_timeout') }}
+    smtp_timeout {{ salt['pillar.get']('keepalived:global_defs:smtp_timeout') }}
 {%- endif %}
 }
 


### PR DESCRIPTION
Fixed reference to `global_defs` section in keepalived pillar structure, where these settings are found in `pillar.example`.