### PR TITLE
refactor formula so that scripts can be defined in the pillar

### DIFF
--- a/keepalived/config.sls
+++ b/keepalived/config.sls
@@ -1,8 +1,28 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{% from "keepalived/map.jinja" import keepalived with context %}
+
 keepalived.config:
+  file.managed:
+    - name: {{ keepalived.conffile }}
+    - source: salt://keepalived/templates/keepalived.jinja
+    - template: jinja
+    - mode: 644
+    - user: root
+    - group: root
+
+
+{%- for script, content in keepalived.get('scripts', {}).items() %}
+keepalived.script_{{script}}:
  file.managed:
-   - name: {{ salt['pillar.get']('keepalived:config_file_path', '/etc/keepalived/keepalived.conf') }}
-   - source: salt://keepalived/templates/keepalived.jinja
-   - template: jinja
+   - name: {{ script }}
+   - contents: |
+      {{content|indent(6)}}
    - user: root
    - group: root
-   - mode: 644
+   - mode: 755
+   - makedirs: True
+   - require_in: 
+     - file: keepalived.config
+{%- endfor %}

--- a/keepalived/init.sls
+++ b/keepalived/init.sls
@@ -6,3 +6,17 @@ include:
   - keepalived.install
   - keepalived.service
   - keepalived.config
+
+
+extend:
+  keepalived.config:
+    file:
+      - require:
+        - pkg: keepalived.install
+  keepalived.service:
+    service:
+      - watch:
+        - file: keepalived.config
+      - require:
+        - pkg: keepalived.install
+

--- a/keepalived/install.sls
+++ b/keepalived/install.sls
@@ -1,3 +1,8 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{% from "keepalived/map.jinja" import keepalived with context %}
+
 keepalived.install:
   pkg.installed:
-    - name: keepalived
+    - pkgs: {{ keepalived.pkgs }}

--- a/keepalived/install.sls
+++ b/keepalived/install.sls
@@ -5,4 +5,4 @@
 
 keepalived.install:
   pkg.installed:
-    - pkgs: {{ keepalived.pkgs }}
+    - pkgs: {{ keepalived.pkgs | tojson }}

--- a/keepalived/map.jinja
+++ b/keepalived/map.jinja
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+{% import_yaml "keepalived/maps/defaults.map" as keepalived_defaults %}
+{% import_yaml "keepalived/maps/osdefaults.map" as keepalived_osdefaults %}
+{% import_yaml "keepalived/maps/os.map" as keepalived_os %}
+
+{% set keepalived_os_family = {} %}
+
+{% do keepalived_os_family.update(keepalived_defaults) %}
+{% do keepalived_os_family.update(keepalived_osdefaults) %}
+{% do keepalived_os_family.update(keepalived_os) %}
+
+{%- set keepalived_default_plus_pillar_lookup = salt['grains.filter_by'](keepalived_os_family, grain='os_family', merge=salt['pillar.get']('keepalived:lookup'), default='osdefaults', base='defaults') %}
+{%- set keepalived = salt['pillar.get']('keepalived', default=keepalived_default_plus_pillar_lookup, merge=True) %}

--- a/keepalived/maps/defaults.map
+++ b/keepalived/maps/defaults.map
@@ -1,0 +1,18 @@
+---
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+
+#defaults settings - OS independent, will be merged with and overridden by OS specific settings
+defaults:
+  pkgs:
+    - keepalived
+  service:
+    name: keepalived
+    state: running
+    enable: True
+  conf:
+    global_defs:
+      smtp_server: localhost
+
+  conffile: '/etc/keepalived/keepalived.conf'

--- a/keepalived/maps/os.map
+++ b/keepalived/maps/os.map
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+#debian (overrides defaults, is taken when os_family grain is Debian)
+Debian:
+  sysconfdir: /etc/default
+
+#redhat (overrides defaults, is taken when os_family grain is RedHat)
+RedHat:
+  sysconfdir: /etc/sysconfig

--- a/keepalived/maps/osdefaults.map
+++ b/keepalived/maps/osdefaults.map
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: ft=yaml
+
+#overrides defaults, used if OS specific settings for current OS could not be found in os.map
+osdefaults:
+  sysconfdir: /etc/sysconfig

--- a/keepalived/service.sls
+++ b/keepalived/service.sls
@@ -1,9 +1,13 @@
+# -*- coding: utf-8 -*-
+# vim: ft=sls
+
+{% from "keepalived/map.jinja" import keepalived with context %}
+
 keepalived.service:
-  service.running:
-    - name: keepalived
-    - enable: True
+  service.{{ keepalived.service.state }}:
+    - name: {{ keepalived.service.name }}
+{% if keepalived.service.state in [ 'running', 'dead' ] %}
+    - enable: {{ keepalived.service.enable }}
     - reload: True
-    - require:
-      - pkg: keepalived
-    - watch:
-      - file: keepalived.config
+{% endif %}
+

--- a/keepalived/templates/keepalived.jinja
+++ b/keepalived/templates/keepalived.jinja
@@ -7,9 +7,5 @@
 {{ '\n' }}
 
 {%- import 'keepalived/templates/config.jinja' as config -%}
-{%- import_yaml 'keepalived/defaults.yaml' as keepalived_defaults -%}
-{%- set keepalived_final_values = salt.pillar.get(
-    'keepalived',
-    default=keepalived_defaults,
-    merge=True) -%}
-{{ config.keepalived_config(keepalived_final_values) }}
+{%- from "keepalived/map.jinja" import keepalived with context -%}
+{{ config.keepalived_config(keepalived.conf) }}

--- a/pillar.example
+++ b/pillar.example
@@ -14,123 +14,151 @@
 # The following would generate the example file in RedHat based systems.
 
 keepalived:
-  global_defs:
-    notification_email:
-      - acassen@firewall.loc
-      - failover@firewall.loc
-      - sysadmin@firewall.loc
-    notification_email_from: Alexandre.Cassen@firewall.loc
-    smtp_server: 192.168.200.1
-    smtp_connect_timeout: 30
-    router_id: LVS_DEVEL
-  vrrp_instance:
-    VI_1:
-      state: MASTER
-      interface: eth0
-      virtual_router_id: 51
-      priority: 100
-      advert_int: 1
-      authentication: 
-        auth_type: PASS
-        auth_pass: 1111
-      virtual_ipaddress:
-        - 192.168.200.16
-        - 192.168.200.17
-        - 192.168.200.18
-  virtual_server:
-    # Virtual and real servers include the port as part of the ID.
-    192.168.200.100 443:
-      delay_loop: 6
-      lb_algo: rr
-      lb_kind: NAT
-      nat_mask: 255.255.255.0
-      persistence_timeout: 50
-      protocol: TCP
-      real_server:
-        192.168.201.100 443:
-          weight: 1
-          SSL_GET:
-            # Must be a list because of multiple URL entries.
-            - url:
-                path: /
-                digest: ff20ad2481f97b1754ef3e12ecd3a9cc
-            - url:
-                path: /mrtg/
-                digest: 9b3a0c85a887a256d6939da88aabd8cd
-            - connect_timeout: 3
-            - nb_get_retry: 3
-            - delay_before_retry: 3
-    10.10.10.2 1358:
-      delay_loop: 6
-      lb_algo: rr
-      lb_kind: NAT
-      persistence_timeout: 50
-      protocol: TCP
-      sorry_server: 192.168.200.200 1358
-      real_server:
-        192.168.200.2 1358:
-          weight: 1
-          HTTP_GET:
-            # Must be a list because of multiple URL entries.
-            - url: 
-                path: /testurl/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334d
-            - url:
-                path: /testurl2/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334d
-            - url:
-                path: /testurl3/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334d
-            - connect_timeout: 3
-            - nb_get_retry: 3
-            - delay_before_retry: 3
-        192.168.200.3 1358:
-          weight: 1
-          HTTP_GET: 
-            - url:
-                path: /testurl/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334c
-            - url:
-                path: /testurl2/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334c
-            - connect_timeout: 3
-            - nb_get_retry: 3
-            - delay_before_retry: 3
-    10.10.10.3 1358:
-      delay_loop: 3
-      lb_algo: rr
-      lb_kind: NAT
-      nat_mask: 255.255.255.0
-      persistence_timeout: 50
-      protocol: TCP
-      real_server: 
-        192.168.200.4 1358:
-          weight: 1
-          HTTP_GET:
-            - url:
-                path: /testurl/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334d
-            - url:
-                path: /testurl2/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334d
-            - url: 
-                path: /testurl3/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334d
-            - connect_timeout: 3
-            - nb_get_retry: 3
-            - delay_before_retry: 3
-        192.168.200.5 1358: 
-          weight: 1
-          HTTP_GET: 
-            - url:
-                path: /testurl/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334d
-            - url:
-                path: /testurl2/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334d
-            - url:
-                path: /testurl3/test.jsp
-                digest: 640205b7b0fc66c1ea91c463fac6334d
-            - connect_timeout: 3
-            - nb_get_retry: 3
-            - delay_before_retry: 3
+  #optional
+  # instead of setting service to "running",
+  # you can set it to enabled so that it will be started on next reboot probably
+  # or to disabled if you want to start keepalived by some kind of clustermanger
+  # manually
+  service:
+    name: keepalived-service-name-on-another-os
+    state: enabled
+
+  #optional
+  # define your own package-names for installing keepalived
+  pkgs:
+    - keepalived
+    - conntrackd
+    - bash-completion
+
+
+  #optional:
+  # place the scripts required for keepalived directly here
+  scripts:
+    /usr/libexec/keepalived/restart_services.sh: |
+      #!/bin/sh
+      logger "NOTICE: restarting named service in order to listen on virtual interfaces"
+      /usr/bin/systemctl restart named.service
+      exit 0
+
+  #content for keepalived.conf
+  conf:
+    global_defs:
+      notification_email:
+        - acassen@firewall.loc
+        - failover@firewall.loc
+        - sysadmin@firewall.loc
+      notification_email_from: Alexandre.Cassen@firewall.loc
+      smtp_server: 192.168.200.1
+      smtp_connect_timeout: 30
+      router_id: LVS_DEVEL
+    vrrp_instance:
+      VI_1:
+        state: MASTER
+        interface: eth0
+        virtual_router_id: 51
+        priority: 100
+        advert_int: 1
+        authentication: 
+          auth_type: PASS
+          auth_pass: 1111
+        virtual_ipaddress:
+          - 192.168.200.16
+          - 192.168.200.17
+          - 192.168.200.18
+    virtual_server:
+      # Virtual and real servers include the port as part of the ID.
+      192.168.200.100 443:
+        delay_loop: 6
+        lb_algo: rr
+        lb_kind: NAT
+        nat_mask: 255.255.255.0
+        persistence_timeout: 50
+        protocol: TCP
+        real_server:
+          192.168.201.100 443:
+            weight: 1
+            SSL_GET:
+              # Must be a list because of multiple URL entries.
+              - url:
+                  path: /
+                  digest: ff20ad2481f97b1754ef3e12ecd3a9cc
+              - url:
+                  path: /mrtg/
+                  digest: 9b3a0c85a887a256d6939da88aabd8cd
+              - connect_timeout: 3
+              - nb_get_retry: 3
+              - delay_before_retry: 3
+      10.10.10.2 1358:
+        delay_loop: 6
+        lb_algo: rr
+        lb_kind: NAT
+        persistence_timeout: 50
+        protocol: TCP
+        sorry_server: 192.168.200.200 1358
+        real_server:
+          192.168.200.2 1358:
+            weight: 1
+            HTTP_GET:
+              # Must be a list because of multiple URL entries.
+              - url: 
+                  path: /testurl/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334d
+              - url:
+                  path: /testurl2/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334d
+              - url:
+                  path: /testurl3/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334d
+              - connect_timeout: 3
+              - nb_get_retry: 3
+              - delay_before_retry: 3
+          192.168.200.3 1358:
+            weight: 1
+            HTTP_GET: 
+              - url:
+                  path: /testurl/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334c
+              - url:
+                  path: /testurl2/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334c
+              - connect_timeout: 3
+              - nb_get_retry: 3
+              - delay_before_retry: 3
+      10.10.10.3 1358:
+        delay_loop: 3
+        lb_algo: rr
+        lb_kind: NAT
+        nat_mask: 255.255.255.0
+        persistence_timeout: 50
+        protocol: TCP
+        real_server: 
+          192.168.200.4 1358:
+            weight: 1
+            HTTP_GET:
+              - url:
+                  path: /testurl/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334d
+              - url:
+                  path: /testurl2/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334d
+              - url: 
+                  path: /testurl3/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334d
+              - connect_timeout: 3
+              - nb_get_retry: 3
+              - delay_before_retry: 3
+          192.168.200.5 1358: 
+            weight: 1
+            HTTP_GET: 
+              - url:
+                  path: /testurl/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334d
+              - url:
+                  path: /testurl2/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334d
+              - url:
+                  path: /testurl3/test.jsp
+                  digest: 640205b7b0fc66c1ea91c463fac6334d
+              - connect_timeout: 3
+              - nb_get_retry: 3
+              - delay_before_retry: 3


### PR DESCRIPTION
I know that this is a huge change, but it fixes some errors and adds the probability to install keepalived scripts to minion by defining the `keepalived.scripts` pillar.

This change is also incompatible, but this is required for ensuring that not every `keepalived.<some_pillar>` ends up in `/etc/keepalived/keepalived.conf`.
The only change required is, you must change your `keepalived` pillar from:
```
keepalived:
  global_defs:
  ...
```
to 
```
keepalived:
  conf:
    global_defs:
    ...
```
Then the formula produces the same result (at least for me)


Bugfix:
- https://github.com/saltstack-formulas/keepalived-formula/blob/ad8e0f6a285634164f06aae07b37dd3992929a40/keepalived/config.sls#L3 
  could never work, because if you define a pillar keepalived.config_file_path this will also an option which ends up in `/etc/keepalived/keepalived.conf`.
- https://github.com/saltstack-formulas/keepalived-formula/blob/ad8e0f6a285634164f06aae07b37dd3992929a40/keepalived/service.sls#L6-L9
  if you only call `... state.sls keepalived.service` this must fail, because pkg: keepalived and file: keepalived.config is not defined
