### PR TITLE
add virtual_server_group to keepalive config template

### DIFF
--- a/keepalived/files/default/keepalived.conf.tmpl.jinja
+++ b/keepalived/files/default/keepalived.conf.tmpl.jinja
@@ -4,7 +4,7 @@
 ########################################################################
 
 {%- from "keepalived/macro.jinja" import print_config %}
-{%- set sections = ['global_defs', 'vrrp_sync_group', 'vrrp_script', 'vrrp_instance', 'virtual_server'] %}
+{%- set sections = ['global_defs', 'vrrp_sync_group', 'vrrp_script', 'vrrp_instance', 'virtual_server', 'virtual_server_group'] %}
 {%- for section in sections %}
 {{ print_config({ section: config[section]|d({}) }) }}
 {%- endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -50,6 +50,11 @@ keepalived:
           - 192.168.200.16
           - 192.168.200.17
           - 192.168.200.18
+    virtual_server_group:
+      dns_TCP:
+        - 10.10.10.53 53
+      dns_UDP:
+        - 10.10.10.53 53
     virtual_server:
       # Virtual and real servers include the port as part of the ID.
       192.168.200.100 443:
@@ -147,6 +152,16 @@ keepalived:
               - connect_timeout: 3
               - nb_get_retry: 3
               - delay_before_retry: 3
+      group dns_TCP:
+        protocol: TCP
+        real_server:
+          10.10.10.1 53:
+            weight: 100
+      group dns_UDP:
+        protocol: TCP
+        real_server:
+          10.10.10.1 53:
+            weight: 100
     vrrp_script:
       check_apache:
         script: '"killall -0 apache"'


### PR DESCRIPTION
By this change You can use virtual_server_group in config

### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [X] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->



### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

This change provide to use virtual_server_group param in pillar because without this it doesn`t work - it does not exist.

You must use virtual_server_group as workaround in case if You have two same server_group (same ip, same port but diffrent protocol - dictionary key error)


### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->

    keepalived:
      config:
        vrrp_instance:
          LVS0:
            state: MASTER
            virtual_router_id: 1

        virtual_server_group:
          dns_TCP:
            - 10.10.10.53 53
          dns_UDP:
            - 10.10.10.53 53

        virtual_server:
          group dns_TCP:
            protocol: TCP
            real_server:
              10.10.10.1 53:
                weight: 100

          group dns_UDP:
            protocol: TCP
            real_server:
              10.10.10.1 53:
                weight: 100

      

### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->


### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [X] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [ ] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->

